### PR TITLE
Support multi line commands, execute selections, and comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,18 @@
         "when": "editorTextFocus && editorLangId == 'azcli'"
       }
     ],
+    "configuration": {
+      "type": "object",
+      "title": "Azure CLI Tools Configuration",
+      "properties": {
+        "ms-azurecli.showResponseInDifferentTab": {
+          "type": "boolean",
+          "default": false,
+          "scope": "resource",
+          "description": "Show response in different tab"
+        }
+      }
+    },
     "menus": {
       "editor/context": [
         {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
     "@types/semver": "5.5.0",
     "tslint": "5.14.0",
     "typescript": "3.3.3333",
-    "vscode": "1.1.30"
+    "vscode": "1.1.30",
+    "elegant-spinner": "1.0.1"
   },
   "dependencies": {
     "jmespath": "0.15.0",

--- a/src/configurationSettings.ts
+++ b/src/configurationSettings.ts
@@ -1,0 +1,50 @@
+import { Event, EventEmitter, window, workspace } from 'vscode';
+
+export interface IAzureCliToolsSettings {
+    showResponseInDifferentTab: boolean;
+}
+
+export class AzureCliToolsSettings implements IAzureCliToolsSettings {
+    public showResponseInDifferentTab: boolean = false;
+
+    private static _instance: AzureCliToolsSettings;
+
+    public static get Instance(): AzureCliToolsSettings {
+        if (!AzureCliToolsSettings._instance) {
+            AzureCliToolsSettings._instance = new AzureCliToolsSettings();
+        }
+
+        return AzureCliToolsSettings._instance;
+    }
+
+    public readonly configurationUpdateEventEmitter = new EventEmitter<void>();
+
+    public get onDidChangeConfiguration(): Event<void> {
+        return this.configurationUpdateEventEmitter.event;
+    }
+
+    private constructor() {
+        workspace.onDidChangeConfiguration(() => {
+            this.initializeSettings();
+            this.configurationUpdateEventEmitter.fire();
+        });
+        window.onDidChangeActiveTextEditor(e => {
+            if (e) {
+                this.initializeSettings();
+                this.configurationUpdateEventEmitter.fire();
+            }
+        });
+
+        this.initializeSettings();
+    }
+
+    private initializeSettings() {
+        const editor = window.activeTextEditor;
+        const document = editor && editor.document;
+
+        const azureCliToolsSettings = workspace.getConfiguration("ms-azurecli", document ? document.uri : null);
+
+        this.showResponseInDifferentTab = azureCliToolsSettings.get<boolean>("showResponseInDifferentTab", false);
+    }
+
+}


### PR DESCRIPTION
Working with JMESPath queries and Kusto queries (in the Resource Graph extension) results in some long commands.

This PR makes it possible to split long commands across several lines, add comments, and execute a selected substring of a longer command.